### PR TITLE
Add a str representation for Type (__str__ magic method)

### DIFF
--- a/jsondataferret/models.py
+++ b/jsondataferret/models.py
@@ -24,6 +24,9 @@ class Type(models.Model):
     title = models.CharField(max_length=200)
     created = models.DateTimeField(auto_now_add=True)
 
+    def __str__(self):
+        return f"{self.public_id}: {self.title}"
+
 
 class RecordManager(models.Manager):
     def filter_needs_moderation_by_type(self, type_model):


### PR DESCRIPTION
This is useful, because this representation is used in the Django admin interface:

![Screenshot from 2022-05-30 17-19-14](https://user-images.githubusercontent.com/634/171174808-866b767e-621c-41af-88b8-02d0c17a4df9.png)
