### PR TITLE
library: release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.7.1] - 2024-05-29
 
 ### Fixed
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="jsondataferret",
-    version="0.7.0",
+    version="0.7.1",
     author="Open Data Services",
     author_email="code@opendataservices.coop",
     packages=[p for p in find_packages() if p.startswith("jsondataferret")],


### PR DESCRIPTION
Releases the changes (from last year) to sql whitespace in this PR: https://github.com/OpenDataServices/json-data-ferret/pull/37/files